### PR TITLE
Minor Fix to display text when invalid command is given

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -22,9 +22,9 @@ public class ListCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Lists all persons in the address book.\n"
             + "Parameters: [sort] [order]\n"
-            + "Example: " + COMMAND_WORD + " sort\n"
-            + "Example: " + COMMAND_WORD + " sort ascending\n"
-            + "Example: " + COMMAND_WORD + " sort reverse";
+            + "Example: " + COMMAND_WORD + "\n"
+            + "Example: " + COMMAND_WORD + " ascending\n"
+            + "Example: " + COMMAND_WORD + " reverse";
 
     /**
      * Represents the sorting order for the list command.


### PR DESCRIPTION
This PR handles a minor edit to display text when invalid command is given

Changes made:
- Update `MESSAGE_USAGE` in `ListCommand.java`

Reviewer to check:
- [x] UI functions as expected
- [x] No error causing the application to exit (e.g. `list ascending reverse`)
- [x] Code edit does not break abstraction
- [x] the PR is sent from a fork, and is from a separate branch
- [ ] commit messages comply with the [Git Conventions](https://nus-cs2103-ay2526-s2.github.io/website/admin/standardsAndConventions.html)