### PR TITLE
Add run-all-checks.sh to automate all checks

### DIFF
--- a/run-all-checks.sh
+++ b/run-all-checks.sh
@@ -2,29 +2,22 @@
 # Run gradle + all check-* scripts, aggregate result
 
 dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 1
-
 ret=0
 
-# 1. Run Gradle checks
-echo "== Running Gradle checks =="
+# Run Gradle checks
+echo "== Running Gradle checks == \n"
 if ! "$dir"/gradlew clean test jacocoTestReport checkstyleMain checkstyleTest check coverage; then
     ret=1
 fi
 
-# 2. Run all check-* scripts
-echo "== Running shell checks =="
-for checkscript in "$dir"/check-*; do
-    [ -e "$checkscript" ] || continue  # skip if none exist
-
-    echo "-- Running $(basename "$checkscript")"
+# Run all check-* scripts, adapted from `.github/run-checks.sh`
+echo "== Running shell checks == \n"
+for checkscript in "$dir"/.github/check-*; do
     if ! "$checkscript"; then
-        echo "❌ Failed: $(basename "$checkscript")"
         ret=1
-    else
-        echo "✅ Passed: $(basename "$checkscript")"
     fi
 done
 
-echo "== Done =="
+echo "== Done == \n"
 
 exit $ret


### PR DESCRIPTION
Adds a bash script to run all `check-* `scripts and Gradle tasks in a single command.

To use this script, simply run:
"./run-all-checks.sh"

If permission is denied, run this (one time only):
"chmod +x run-all-checks.sh"

Reviewers to do:
- [x] Confirm that the test script applies all checks as intended.