### PR TITLE
Fixes #222 #236 #228: Fix find command and UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -339,9 +339,12 @@ Use `;` to split phrases into multiple keyword groups, e.g. `find -n alice pauli
 
 * At least one of `-n` or `-t` must be provided.
 * The search is case-insensitive. e.g. `alice` will match `Alice`.
-* Use `;` to separate multiple keyword groups. Each keyword group can contain spaces.
-* `-m or` matches contacts that contain **any** of the keyword groups for the preceding field (default).
-* `-m and` matches contacts that contain **all** of the keyword groups for the preceding field.
+* A **keyword group** is one phrase inside a field (one or more alphanumeric words), e.g. `alice pauline`.
+* Use `;` to separate multiple keyword groups within the same field (`-n` or `-t`).
+* The `-m` keyword is **OPTIONAL**. By default, keyword groups in a field use `OR` logic (`-m or`).
+* `-m or` matches contacts that contain **any** keyword group of the preceding field.
+* `-m and` matches contacts that contain **all** keyword groups of the preceding field.
+* For `;`-separated groups, evaluation is done within that field only: the groups are combined by that field's `-m` mode.
 * `-m and|or` must come after a `-n` or `-t` keyword group; it cannot appear before both fields.
 * If both `-n` and `-t` are provided, a person must satisfy both fields.
 * Matching is based on text containment. e.g. `ali` will match `Alice`.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -120,7 +120,7 @@ To ensure this guide is effective, we assume the target user:
 * Items with `…`​ after them can be used multiple times including zero times.<br>
   e.g. `[-t TAG]…​` can be used as ` ` (i.e. 0 times), `-t friend`, `-t friend -t family` etc.
 
-* Parameters can be in any order.<br>
+* Parameters can be in any order (except `FIND` keyword).<br>
   e.g. if the command specifies `-n NAME -p PHONE_NUMBER`, `-p PHONE_NUMBER -n NAME` is also acceptable.
 
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `exit` and `clear`, or `y`/`n` for confirmation command) will be ignored.<br>
@@ -342,6 +342,7 @@ Use `;` to split phrases into multiple keyword groups, e.g. `find -n alice pauli
 * Use `;` to separate multiple keyword groups. Each keyword group can contain spaces.
 * `-m or` matches contacts that contain **any** of the keyword groups for the preceding field (default).
 * `-m and` matches contacts that contain **all** of the keyword groups for the preceding field.
+* `-m and|or` must come after a `-n` or `-t` keyword group; it cannot appear before both fields.
 * If both `-n` and `-t` are provided, a person must satisfy both fields.
 * Matching is based on text containment. e.g. `ali` will match `Alice`.
 * Keywords can only contain alphanumeric characters and spaces.
@@ -351,6 +352,7 @@ Examples:
 * `find -t RAG2026 ; finance ; secretaries -m and` returns persons with tags containing all listed groups.
 * `find -n dan ; elle -m and -t friends ; student -m or` returns persons whose names contain both `dan` and `elle`,
   and tags containing `friends` or `student`.
+* Invalid: `find -m and -n name1 ; name2` (`-m` cannot come before `-n`/`-t`).
 * `find -n heng ; kang -m and` returns persons whose names contain both `heng` and `kang`.<br>
   ![result for 'find -n heng ; kang'](images/findNameHengKang.png)
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -208,7 +208,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         Stream<String> keywordStream = trimmedQuery.contains(";")
-                ? Stream.of(trimmedQuery.split(";"))
+                ? Stream.of(trimmedQuery.split(";", -1))
                 : Stream.of(trimmedQuery);
 
         List<String> keywords = keywordStream

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -116,14 +116,11 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_trailingSemicolon_success() throws CommandException {
-        FindCommand expectedNameCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Collections.singletonList("Alice")));
-        assertParseSuccess(parser, " -n Alice ;", expectedNameCommand);
-
-        FindCommand expectedTagCommand =
-                new FindCommand(new TagContainsKeywordsPredicate(Collections.singletonList("friend")));
-        assertParseSuccess(parser, " -t friend ;", expectedTagCommand);
+    public void parse_trailingSemicolon_throwsParseException() {
+        String invalidFormatMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, " -n Alice ;", invalidFormatMessage);
+        assertParseFailure(parser, " -t friend ;", invalidFormatMessage);
+        assertParseFailure(parser, " -n alice ; -m and", invalidFormatMessage);
     }
 
     @Test


### PR DESCRIPTION
Reviewers to check:
- [ ] The application should reject this command with an "invalid command format" error. A semicolon should strictly require a valid alphanumeric keyword group on both sides of it. Eg: `find -n alice ;` is invalid
- [ ] UG specifies that parameter can be in any order except `Find` command
- [ ] Make `Find` command much more clearer to understand in UG

Fixes #222 
Fixes #228 
Fixes #236 