### PR TITLE
Fixes #175: Fix bug change name format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,34 +46,34 @@ task coverage(type: JacocoReport) {
 }
 
 dependencies {
+    def osName = System.getProperty("os.name").toLowerCase()
+    def osArch = System.getProperty("os.arch").toLowerCase()
+
+    def javaFxPlatform
+    if (osName.contains("win")) {
+        javaFxPlatform = "win"
+    } else if (osName.contains("mac")) {
+        javaFxPlatform = (osArch.contains("aarch64") || osArch.contains("arm64")) ? "mac-aarch64" : "mac"
+    } else {
+        javaFxPlatform = "linux"
+    }
+
     String jUnitVersion = '5.4.0'
     String javaFxVersion = '17.0.7'
 
-    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
-    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
-    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'linux'
-    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'win'
-    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'mac'
-    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'linux'
-    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'win'
-    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'mac'
-    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'linux'
-    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
-    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
-    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: javaFxPlatform
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: javaFxPlatform
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: javaFxPlatform
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: javaFxPlatform
+    implementation group: 'org.openjfx', name: 'javafx-web', version: javaFxVersion, classifier: javaFxPlatform
+    implementation group: 'org.openjfx', name: 'javafx-media', version: javaFxVersion, classifier: javaFxPlatform
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
-
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }
-
-run {
-    enableAssertions = true
-}
-
 
 shadowJar {
     archiveFileName = 'campusconnect.jar'

--- a/build.gradle
+++ b/build.gradle
@@ -46,34 +46,34 @@ task coverage(type: JacocoReport) {
 }
 
 dependencies {
-    def osName = System.getProperty("os.name").toLowerCase()
-    def osArch = System.getProperty("os.arch").toLowerCase()
-
-    def javaFxPlatform
-    if (osName.contains("win")) {
-        javaFxPlatform = "win"
-    } else if (osName.contains("mac")) {
-        javaFxPlatform = (osArch.contains("aarch64") || osArch.contains("arm64")) ? "mac-aarch64" : "mac"
-    } else {
-        javaFxPlatform = "linux"
-    }
-
     String jUnitVersion = '5.4.0'
     String javaFxVersion = '17.0.7'
 
-    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: javaFxPlatform
-    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: javaFxPlatform
-    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: javaFxPlatform
-    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: javaFxPlatform
-    implementation group: 'org.openjfx', name: 'javafx-web', version: javaFxVersion, classifier: javaFxPlatform
-    implementation group: 'org.openjfx', name: 'javafx-media', version: javaFxVersion, classifier: javaFxPlatform
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
+
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }
+
+run {
+    enableAssertions = true
+}
+
 
 shadowJar {
     archiveFileName = 'campusconnect.jar'

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -827,6 +827,12 @@ testers are expected to do more *exploratory* testing.
     4. Test case: `find -n John; alice`<br>
        Expected: Contacts matching "John" and "alice" are displayed (case-insensitive).
 
+    5. Test case: `find -n Mary-Anne`  
+       Expected: All contacts with names containing `Mary-Anne` are displayed.
+
+    6. Test case: `find -n O'Brien`  
+       Expected: All contacts with names containing `O'Brien` are displayed.
+
 2. Finding persons by partial match
 
     1. Prerequisites: The app contains contacts such as "Jonathan", "Johnny", "John Doe".

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -344,10 +344,12 @@ Use `;` to split phrases into multiple keyword groups, e.g. `find -n alice pauli
 * `-m and` matches contacts that contain **all** of the keyword groups for the preceding field.
 * If both `-n` and `-t` are provided, a person must satisfy both fields.
 * Matching is based on text containment. e.g. `ali` will match `Alice`.
-* Keywords can only contain alphanumeric characters and spaces.
+* Name keywords can contain alphanumeric characters, spaces, and common punctuation such as `.`, `'`, `/`, and `-`.
+* Tag keywords can only contain alphanumeric characters and spaces.
 
 Examples:
 * `find -n alice pauline ; josh -m or` returns persons whose names contain `alice pauline` or `josh`.
+* `find -n Ahmad s/o Ibrahim` returns persons whose names contain `Ahmad s/o Ibrahim`.
 * `find -t RAG2026 ; finance ; secretaries -m and` returns persons with tags containing all listed groups.
 * `find -n dan ; elle -m and -t friends ; student -m or` returns persons whose names contain both `dan` and `elle`,
   and tags containing `friends` or `student`.

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -21,6 +21,9 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_CONTAINS_NON_ALPHANUMERIC_CHARACTER = "Only give alphanumeric keywords";
+    public static final String MESSAGE_INVALID_NAME_KEYWORD =
+            "Name keywords should only contain alphanumeric characters, spaces, and common punctuation "
+                    + "(. ' / -)";
     public static final String MESSAGE_ONLY_YES_NO = "Please enter either \'y\' or \'n\'";
     public static final String MESSAGE_SUCCESSFUL_CANCEL = "%1$s command cancelled.";
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,13 +10,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters, spaces, and common punctuation "
+                    + "(. ' / -), and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    private static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} .'/\\-]*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -11,8 +11,8 @@ import seedu.address.logic.commands.exceptions.CommandException;
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Person> {
-    private static final String KEYWORD_VALIDATION_REGEX = "^[a-zA-Z0-9]+( [a-zA-Z0-9]+)*$";
-
+    private static final String KEYWORD_VALIDATION_REGEX =
+            "^[\\p{Alnum}][\\p{Alnum} .'/\\-]*$";
     private final List<String> keywords;
     private final KeywordRelation relation;
 
@@ -35,7 +35,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
      */
     public NameContainsKeywordsPredicate(List<String> keywords, KeywordRelation relation) throws CommandException {
         if (keywords.stream().anyMatch(keyword -> !keyword.matches(KEYWORD_VALIDATION_REGEX))) {
-            throw new CommandException(Messages.MESSAGE_CONTAINS_NON_ALPHANUMERIC_CHARACTER);
+            throw new CommandException(Messages.MESSAGE_INVALID_NAME_KEYWORD);
         }
 
         this.keywords = keywords;

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_CONTAINS_NON_ALPHANUMERIC_CHARACTER;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NAME_KEYWORD;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -105,7 +106,7 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_invalidKeyword_throwsCommandException() {
-        assertParseFailure(parser, " -n Alice Bob!", MESSAGE_CONTAINS_NON_ALPHANUMERIC_CHARACTER);
+        assertParseFailure(parser, " -n Alice Bob!", MESSAGE_INVALID_NAME_KEYWORD);
         assertParseFailure(parser, " -t friend!", MESSAGE_CONTAINS_NON_ALPHANUMERIC_CHARACTER);
         assertParseFailure(parser, " -n alice ; ; bob",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -72,6 +73,19 @@ public class NameContainsKeywordsPredicateTest {
         // Multi-word keyword phrase
         predicate = new NameContainsKeywordsPredicate(Collections.singletonList("alice bob"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Keywords with newly allowed punctuation
+        predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Mary-Anne"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Mary-Anne Lee").build()));
+
+        predicate = new NameContainsKeywordsPredicate(Collections.singletonList("O'Brien"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Tim O'Brien").build()));
+
+        predicate = new NameContainsKeywordsPredicate(Collections.singletonList("s/o"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Ahmad s/o Ibrahim").build()));
+
+        predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Dr."));
+        assertTrue(predicate.test(new PersonBuilder().withName("Dr. John Smith").build()));
     }
 
     @Test
@@ -95,11 +109,15 @@ public class NameContainsKeywordsPredicateTest {
     public void constructor_invalidKeyword_throwsCommandException() {
         CommandException exception = assertThrows(CommandException.class, () ->
                 new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob!")));
-        assertEquals(Messages.MESSAGE_CONTAINS_NON_ALPHANUMERIC_CHARACTER, exception.getMessage());
+        assertEquals(Messages.MESSAGE_INVALID_NAME_KEYWORD, exception.getMessage());
+    }
 
-        exception = assertThrows(CommandException.class, () ->
-                new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob-Charles")));
-        assertEquals(Messages.MESSAGE_CONTAINS_NON_ALPHANUMERIC_CHARACTER, exception.getMessage());
+    @Test
+    public void constructor_validKeywordWithCommonPunctuation_doesNotThrow() {
+        assertDoesNotThrow(() -> new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob-Charles")));
+        assertDoesNotThrow(() -> new NameContainsKeywordsPredicate(Arrays.asList("O'Brien")));
+        assertDoesNotThrow(() -> new NameContainsKeywordsPredicate(Arrays.asList("Ahmad s/o Ibrahim")));
+        assertDoesNotThrow(() -> new NameContainsKeywordsPredicate(Arrays.asList("Dr. John")));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -27,8 +27,8 @@ public class NameTest {
         // invalid name
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
-        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
-        assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("^")); // only non-allowed characters
+        assertFalse(Name.isValidName("peter*")); // contains non-allowed characters
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
@@ -36,6 +36,13 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+
+        // valid names with common punctuation
+        assertTrue(Name.isValidName("Mary-Anne")); // hyphen
+        assertTrue(Name.isValidName("O'Brien")); // apostrophe
+        assertTrue(Name.isValidName("Ahmad s/o Ibrahim")); // slash
+        assertTrue(Name.isValidName("Dr. John")); // period
+        assertTrue(Name.isValidName("Lee Kuan-Yew")); // multiple words with hyphen
     }
 
     @Test


### PR DESCRIPTION
This PR updates name validation to support common real-world punctuation, and aligns the related logic, tests, and documentation with the new behavior.

Changes made:
- Relaxed `Name` validation to allow common punctuation such as `.`, `'`, `/`, and `-`.
- Updated name-keyword validation in `find` so punctuation-containing names can be searched consistently.
- Revised the related user-facing validation message to reflect the new accepted format.
- Updated tests for `Name` and `NameContainsKeywordsPredicate` to cover the relaxed validation rules.
- Updated the User Guide and Developer Guide to document the new behavior and examples.

Reviewer to check:
- [ ] Names with common punctuation such as `Mary-Anne`, `O'Brien`, `Dr. John`, and `Ahmad s/o Ibrahim` are accepted
- [ ] `find` supports name keywords with the same allowed punctuation
- [ ] Invalid characters such as `!` and `*` are still rejected
- [ ] The updated validation message matches the current implementation
- [ ] The User Guide and Developer Guide are consistent with the new behavior
- [ ] the PR is sent from a fork, and is from a separate branch
- [ ] commit messages comply with the [Git Conventions](https://nus-cs2103-ay2526-s2.github.io/website/admin/standardsAndConventions.html)

Fixes #175